### PR TITLE
feat: Add deployment region configuration and fix Nova Canvas availability docs

### DIFF
--- a/cdk/bin/vto-app.ts
+++ b/cdk/bin/vto-app.ts
@@ -21,10 +21,11 @@ const wafStack = new FrontendWafStack(app, 'VtoAppFrontendWafStack', {
 });
 
 // メインのアプリケーションスタック
+const deploymentRegion = app.node.tryGetContext('deploymentRegion') || process.env.CDK_DEFAULT_REGION;
 new VtoAppStack(app, 'VtoAppStack', {
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT, 
-    region: process.env.CDK_DEFAULT_REGION
+    region: deploymentRegion
   },
   crossRegionReferences: true, // クロスリージョン参照を有効化
   wafWebAclArn: wafStack.webAclArn.value, // us-east-1のWAF ARNを参照

--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -30,6 +30,7 @@
       "admin"
     ],
     "selfSignUpEnabled": true,
+    "deploymentRegion": "us-east-1",
     "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
     "@aws-cdk/core:checkSecretUsage": true,
     "@aws-cdk/core:target-partitions": [

--- a/docs/en/DEPLOYMENT.md
+++ b/docs/en/DEPLOYMENT.md
@@ -2,8 +2,8 @@
 
 ## Prerequisites
 ### Bedrock
-Enable Nova models in regions such as us-east-1/us-west-2. This sample uses Nova Canvas image generation models and Nova Micro/Lite text models.
-Go to [Bedrock Model access](https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-west-2#/modelaccess) > `Manage model access`, check the entire Nova model family, and click `Save changes`.
+Enable Nova models in one of the following regions: us-east-1, ap-northeast-1, or eu-west-1. This sample uses Nova Canvas image generation models (only available in us-east-1, ap-northeast-1, and eu-west-1) and Nova Micro/Lite text models.
+Go to [Bedrock Model access](https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/modelaccess) > `Manage model access`, check the entire Nova model family, and click `Save changes`.
 
 ### CDK Execution Environment
 To deploy CDK projects, the following environment is required. Please set up the environment in advance.
@@ -20,7 +20,7 @@ To deploy CDK projects, the following environment is required. Please set up the
 
 ```bash
 # Install CDK dependencies
-cd vto-app/cdk
+cd cdk
 npm install
 
 # Install frontend dependencies
@@ -31,7 +31,7 @@ npm install
 ### 2. CDK Bootstrap (First time only)
 
 ```bash
-cd vto-app/cdk
+cd cdk
 npx cdk bootstrap
 ```
 
@@ -43,6 +43,7 @@ By modifying [cdk.json](../../cdk/cdk.json) during deployment, security enhancem
 - allowedIpV6AddressRanges: Comma-separated list of allowed IPv6 ranges. (Default: allows all IPv6 addresses)
 - allowedSignUpEmailDomains: Comma-separated list of email domains allowed during sign-up. (Default: no domain restrictions)
 - autoJoinUserGroups: Comma-separated list of Cognito user groups that new users automatically join. (Default: admin)
+- deploymentRegion: Deployment region. Specify a region where Nova Canvas is available (us-east-1, ap-northeast-1, eu-west-1). (Default: us-east-1)
 
 ```json
 {
@@ -53,7 +54,8 @@ By modifying [cdk.json](../../cdk/cdk.json) during deployment, security enhancem
     "userPoolDomainPrefix": "",
     "allowedSignUpEmailDomains": [],
     "autoJoinUserGroups": ["admin"],
-    "selfSignUpEnabled": true
+    "selfSignUpEnabled": true,
+    "deploymentRegion": "us-east-1"
   }
 }
 ```
@@ -62,7 +64,7 @@ By modifying [cdk.json](../../cdk/cdk.json) during deployment, security enhancem
 ### Full Deployment (Recommended)
 
 ```bash
-cd vto-app/cdk
+cd cdk
 npx cdk deploy --all --require-approval never --outputs-file ./.cdk-outputs.json
 ```
 Upon completion of deployment, the following outputs will be displayed:
@@ -85,5 +87,5 @@ For production use, we strongly recommend adding IP address restrictions or disa
 To delete resources:
 
 ```bash
-cd vto-app/cdk
+cd cdk
 npx cdk destroy --all

--- a/docs/ja/DEPLOYMENT.md
+++ b/docs/ja/DEPLOYMENT.md
@@ -2,8 +2,8 @@
 
 ## 事前準備
 ### Bedrock
-us-east-1/us-west-2 リージョンなどで、Nova モデルの有効化を行ってください。本サンプルではNova Canvasの画像生成モデルと Nova Micro/Lite などのテキストモデルを使用しています。
-[Bedrock Model access](https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-west-2#/modelaccess) > `Manage model access` からNovaモデルファミリー一式をチェックし、`Save changes`をクリックします
+us-east-1、ap-northeast-1、eu-west-1 のいずれかのリージョンで、Nova モデルの有効化を行ってください。本サンプルではNova Canvasの画像生成モデル（us-east-1、ap-northeast-1、eu-west-1でのみ利用可能）と Nova Micro/Lite などのテキストモデルを使用しています。
+[Bedrock Model access](https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/modelaccess) > `Manage model access` からNovaモデルファミリー一式をチェックし、`Save changes`をクリックします
 ### CDK実行環境
 CDK のプロジェクトをデプロイするには、以下の環境が必要です。事前に環境のセットアップを実施してください。
 
@@ -42,6 +42,7 @@ npx cdk bootstrap
 - allowedIpV6AddressRanges: 許可する IPv6 範囲のカンマ区切りリスト。（デフォルト: 全ての IPv6 アドレスを許可）
 - allowedSignUpEmailDomains: サインアップ時に許可するメールドメインのカンマ区切りリスト。（デフォルト: ドメイン制限なし）
 - autoJoinUserGroups: 新規ユーザー自動参加cognitoユーザーグループのカンマ区切りリスト。（デフォルト: admin）
+- deploymentRegion: デプロイ先リージョン。Nova Canvasが利用可能なリージョン（us-east-1、ap-northeast-1、eu-west-1）を指定してください。（デフォルト: us-east-1）
 
 ```json
 {
@@ -52,7 +53,8 @@ npx cdk bootstrap
     "userPoolDomainPrefix": "",
     "allowedSignUpEmailDomains": [],
     "autoJoinUserGroups": ["admin"],
-    "selfSignUpEnabled": true
+    "selfSignUpEnabled": true,
+    "deploymentRegion": "us-east-1"
   }
 }
 ```


### PR DESCRIPTION
  ## Summary
  - Added deploymentRegion parameter to cdk.json for flexible region deployment
  - Fixed Nova Canvas region availability documentation to reflect actual availability
  - Fixed incorrect directory paths in deployment documentation

  ## Changes
  ### Configuration Enhancement
  - Added `deploymentRegion` parameter to cdk.json (default: us-east-1)
  - Updated CDK to use deploymentRegion from context, allowing easy region switching

  ### Documentation Fixes
  - Removed us-west-2 from Nova Canvas supported regions
  - Added ap-northeast-1 and eu-west-1 as supported regions
  - Updated Bedrock console URL from us-west-2 to us-east-1
  - Fixed directory path in English docs: `vto-app/cdk` → `cdk`