### PR TITLE
[frontend] fix: update CFG scale default values to 6.5 for VTO and Model Generation

### DIFF
--- a/frontend/src/stores/appStore.ts
+++ b/frontend/src/stores/appStore.ts
@@ -29,7 +29,7 @@ const defaultVTOParameters: VTOParameters = {
   returnMask: false,
   numberOfImages: 1,
   quality: 'standard',
-  cfgScale: 3.0,
+  cfgScale: 6.5, // default value: 6.5
   seed: -1,
 };
 
@@ -37,7 +37,7 @@ const defaultVTOParameters: VTOParameters = {
 const defaultModelGenerationParameters: ModelGenerationParameters = {
   prompt: '',
   modelId: 'amazon.nova-canvas-v1:0',
-  cfgScale: 8.0,
+  cfgScale: 6.5, // default value: 6.5
   height: 1024,
   width: 1024,
   numberOfImages: 1,


### PR DESCRIPTION
*Description of changes:*
The default value of the cfg scale was changed to 6.5 in order to align it with the Amazon Nova Canvas default value.
